### PR TITLE
chore: remove devcontainer from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,11 +16,3 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "fix: "
-
-  - package-ecosystem: "devcontainers"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    commit-message:
-      prefix: "chore: "


### PR DESCRIPTION
Removed devcontainers configuration from Dependabot settings.